### PR TITLE
Change the S-Tag used for generating a random number

### DIFF
--- a/LuminateTips/README.md
+++ b/LuminateTips/README.md
@@ -8,7 +8,7 @@ Luminate Tips and Tricks
 Retrieve the value of your session variable with S80
 Ex. ```[[S80:foo]]``` would return "bar"
 * **Manually Set a Pagewrapper** - ```&pgwrap={####}```
-* **Force Browser to Always Load Current External File** - ```styles.css?v=[[S55:0:10000:5]]```
+* **Force Browser to Always Load Current External File** - ```styles.css?v=[[S55:0,1000,5]]```
 * **Preview Donation Form** - ```&df_preview=true ```
 * **View Reusable Pagebuilder Names in Source** - ```&s_debug=true```
 * **View Template Names** in Source - ```&s_dev_templates=true```


### PR DESCRIPTION
The syntax for generating a random number in Luminate was not formatted correctly. The random number would not be 5 digits long and would actually output the number "5". The min, max, and minimum digits are comma separated values https://www.blackbaud.com/support/howto/coveo/luminate-online/Subsystems/S-Tags/S-Tags/S55_Random_Number.html